### PR TITLE
BLD: Update template to be prefect 2.0+ and lume-model v1.7.0 compatible

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,9 @@ dependencies:
   - python=3.9
   - cookiecutter
   - versioneer
-  - lume-model
   - pytablewriter
   - gitpython
   - jupyterlab
   - tree
+  - pip:
+    - git+https://github.com/slaclab/lume-model.git  # Until lume-model updated in conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
+  - pip
   - cookiecutter
   - versioneer
   - pytablewriter

--- a/examples/variables.yml
+++ b/examples/variables.yml
@@ -3,25 +3,27 @@ input_variables:
       name: input1
       type: scalar
       default: 1
-      range: [0, 256]
+      value_range: [0, 256]
 
   input2:
       name: input2
       type: scalar
       default: 2.0
-      range: [0, 256]
+      value_range: [0, 256]
 
 output_variables:
   output1:
     name: output1
-    type: image
-    x_label: "value1"
-    y_label: "value2"
-    axis_units: ["mm", "mm"]
-    x_min: 0
-    x_max: 10
-    y_min: 0
-    y_max: 10
+    type: scalar
+# Use of image type pending updates to lume-model to support it again
+#    type: image
+#    x_label: "value1"
+#    y_label: "value2"
+#    axis_units: ["mm", "mm"]
+#    x_min: 0
+#    x_max: 10
+#    y_min: 0
+#    y_max: 10
 
   output2:
     name: output2

--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -9,5 +9,6 @@
     "model_class":"{{ cookiecutter.project_name.title().replace(' ', '').replace('-', '') }}",
     "container_registry": ["DockerHub", "Stanford Container Registry"],
     "registry_username": null,
-    "model_config_file": null
+    "model_config_file": null,
+    "_copy_without_render": ["prefect.yaml"]
 }

--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -9,6 +9,5 @@
     "model_class":"{{ cookiecutter.project_name.title().replace(' ', '').replace('-', '') }}",
     "container_registry": ["DockerHub", "Stanford Container Registry"],
     "registry_username": null,
-    "model_config_file": null,
-    "_copy_without_render": ["prefect.yaml"]
+    "model_config_file": null
 }

--- a/template/hooks/post_gen_project.py
+++ b/template/hooks/post_gen_project.py
@@ -5,7 +5,7 @@ from subprocess import Popen
 
 from pytablewriter import MarkdownTableWriter
 from lume_model.utils import variables_from_yaml
-from lume_model.variables import Variable, ArrayVariable, TableVariable, ScalarVariable, ImageVariable
+from lume_model.variables import Variable, ScalarVariable
 import logging
 
 
@@ -16,17 +16,18 @@ logging.basicConfig(level=logging.INFO)
 def get_var_type(variable: Variable):
 
     type_str = None
-    if isinstance(variable, (ArrayVariable,)):
-        type_str = "array"
-
-    elif isinstance(variable, (ScalarVariable,)):
+    if isinstance(variable, (ScalarVariable,)):
         type_str = "scalar"
 
-    elif isinstance(variable, (ImageVariable,)):
-        type_str = "image"
+#  Waiting on reimplementation in new version of lume-model
+#    elif isinstance(variable, (ArrayVariable,)):
+#        type_str = "array"
 
-    elif isinstance(variable, (TableVariable,)):
-        type_str = "table"
+#    elif isinstance(variable, (ImageVariable,)):
+#        type_str = "image"
+
+#    elif isinstance(variable, (TableVariable,)):
+#        type_str = "table"
 
     else:
         raise ValueError("Variable type not found: %s", variable.__name__)
@@ -56,8 +57,7 @@ class LUMEModelVariableProcessor():
         self.output_variables = None
 
         try:
-            with open(filename, "r") as f:
-                self.input_variables, self.output_variables = variables_from_yaml(f)
+            self.input_variables, self.output_variables = variables_from_yaml(filename)
 
         except Exception as e:
             logger.exception(e)
@@ -67,16 +67,16 @@ class LUMEModelVariableProcessor():
         input_table = None
         output_table=None
 
-        input_var_matrix = [[var.name, get_var_type(var), var.default] for var in self.input_variables.values()]
+        input_var_matrix = [[var.name, get_var_type(var), var.default] for var in self.input_variables]
 
         if len(self.input_variables) > 0:
 
             if len(self.input_variables) == 1:
-                var = list(self.input_variables.values())[0]
+                var = list(self.input_variables)[0]
                 output_var_matrix = [var.name, get_var_type(var), var.default]
             
             else:
-                output_var_matrix = [[var.name, get_var_type(var), var.default] for var in self.input_variables.values()]
+                output_var_matrix = [[var.name, get_var_type(var), var.default] for var in self.input_variables]
 
 
             input_variable_table_writer =  MarkdownTableWriter(
@@ -90,11 +90,11 @@ class LUMEModelVariableProcessor():
         if len(self.output_variables) > 0:
 
             if len(self.output_variables) == 1:
-                var = list(self.output_variables.values())[0]
+                var = list(self.output_variables)[0]
                 output_var_matrix = [var.name, get_var_type(var)]
             
             else:
-                output_var_matrix = [[var.name, get_var_type(var)] for var in self.output_variables.values()]
+                output_var_matrix = [[var.name, get_var_type(var)] for var in self.output_variables]
 
 
             output_variable_table_writer =  MarkdownTableWriter(

--- a/template/{{ cookiecutter.repo_name }}/Dockerfile
+++ b/template/{{ cookiecutter.repo_name }}/Dockerfile
@@ -2,8 +2,11 @@ FROM condaforge/mambaforge AS build
 
 COPY environment.yml /{{ cookiecutter.repo_name }}/environment.yml
 
-RUN conda install -c conda-forge conda-pack && \
-  conda env create -f /{{ cookiecutter.repo_name }}/environment.yml
+RUN apt-get update && \
+    apt-get install -y gcc git build-essential
+
+RUN mamba install -c conda-forge conda-pack && \
+  mamba env create -f /{{ cookiecutter.repo_name }}/environment.yml
 
 # Use conda-pack to create a  enviornment in /venv:
 RUN conda-pack -n {{ cookiecutter.repo_name }} -o /tmp/env.tar && \

--- a/template/{{ cookiecutter.repo_name }}/environment.yml
+++ b/template/{{ cookiecutter.repo_name }}/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - lume-model # until lume-services registered with conda
   - pip 
   - pip: 
-    - git+https://github.com/slaclab/lume-services.git@main
+    - git+https://github.com/jbellister-slac/lume-services.git@prefect_2

--- a/template/{{ cookiecutter.repo_name }}/environment.yml
+++ b/template/{{ cookiecutter.repo_name }}/environment.yml
@@ -2,8 +2,8 @@ name: {{ cookiecutter.repo_name }}
 channels:
   - conda-forge
 dependencies:
-  - prefect<2.0 # until lume-services registered with conda
-  - lume-model>=1.4 # until lume-services registered with conda
+  - prefect # until lume-services registered with conda
+  - lume-model # until lume-services registered with conda
   - pip 
   - pip: 
     - git+https://github.com/slaclab/lume-services.git@main

--- a/template/{{ cookiecutter.repo_name }}/environment.yml
+++ b/template/{{ cookiecutter.repo_name }}/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - prefect # until lume-services registered with conda
-  - lume-model # until lume-services registered with conda
   - pip 
   - pip: 
     - git+https://github.com/jbellister-slac/lume-services.git@prefect_2
+    - git+https://github.com/slaclab/lume-model.git  # Until lume-model updated in conda-forge

--- a/template/{{ cookiecutter.repo_name }}/prefect.yaml
+++ b/template/{{ cookiecutter.repo_name }}/prefect.yaml
@@ -7,7 +7,7 @@ build:
 - prefect_docker.deployments.steps.build_docker_image:
     id: build-image
     requires: prefect-docker>=0.4.0
-    image_name: '{{ $PREFECT_IMAGE_NAME }}'
+    image_name: {% raw %}'{{ $PREFECT_IMAGE_NAME }}'{% endraw %}
     tag: latest
     dockerfile: Dockerfile
     platform: linux/amd64
@@ -16,12 +16,12 @@ build:
 push:
 - prefect_docker.deployments.steps.push_docker_image:
     requires: prefect-docker>=0.4.0
-    image_name: '{{ build-image.image_name }}'
-    tag: '{{ build-image.tag }}'
+    image_name: {% raw %}'{{ build-image.image_name }}'{% endraw %}
+    tag: {% raw %}'{{ build-image.tag }}'{% endraw %}
 
 pull:
 - prefect.deployments.steps.set_working_directory:
-    directory: /{{ cookiecutter.repo_name }}
+    directory: {% raw %}/{{ cookiecutter.repo_name }}{% endraw %}
 
 # the definitions section allows you to define reusable components for your deployments
 definitions:
@@ -30,7 +30,7 @@ definitions:
   work_pool:
     name: kubernetes-work-pool
     job_variables:
-      image: '{{ build-image.image }}'
+      image: {% raw %}'{{ build-image.image }}'{% endraw %}
 
 # the deployments section allows you to provide configuration for deploying flows
 deployments:
@@ -41,9 +41,9 @@ deployments:
   work_pool:
     name: kubernetes-work-pool
     job_variables:
-      image: '{{ build-image.image }}'
+      image: {% raw %}'{{ build-image.image }}'{% endraw %}
     work_queue_name:
   version:
   description:
-  entrypoint: torch_model/flow.py:torch_nn_flow
+  entrypoint: {{ cookiecutter.package }}/flow.py:{{ cookiecutter.package }}_flow
   parameters: {}

--- a/template/{{ cookiecutter.repo_name }}/prefect.yaml
+++ b/template/{{ cookiecutter.repo_name }}/prefect.yaml
@@ -1,0 +1,49 @@
+# Generic metadata about this project
+name: flows
+prefect-version: 2.14.2
+
+# build section allows you to manage and build docker images
+build:
+- prefect_docker.deployments.steps.build_docker_image:
+    id: build-image
+    requires: prefect-docker>=0.4.0
+    image_name: '{{ $PREFECT_IMAGE_NAME }}'
+    tag: latest
+    dockerfile: Dockerfile
+    platform: linux/amd64
+
+# push section allows you to manage if and how this project is uploaded to remote locations
+push:
+- prefect_docker.deployments.steps.push_docker_image:
+    requires: prefect-docker>=0.4.0
+    image_name: '{{ build-image.image_name }}'
+    tag: '{{ build-image.tag }}'
+
+pull:
+- prefect.deployments.steps.set_working_directory:
+    directory: /{{ cookiecutter.repo_name }}
+
+# the definitions section allows you to define reusable components for your deployments
+definitions:
+  tags:
+  - lume
+  work_pool:
+    name: kubernetes-work-pool
+    job_variables:
+      image: '{{ build-image.image }}'
+
+# the deployments section allows you to provide configuration for deploying flows
+deployments:
+- name: default
+  tags:
+  - lume
+  schedule:
+  work_pool:
+    name: kubernetes-work-pool
+    job_variables:
+      image: '{{ build-image.image }}'
+    work_queue_name:
+  version:
+  description:
+  entrypoint: torch_model/flow.py:torch_nn_flow
+  parameters: {}

--- a/template/{{ cookiecutter.repo_name }}/{{ cookiecutter.package }}/__init__.py
+++ b/template/{{ cookiecutter.repo_name }}/{{ cookiecutter.package }}/__init__.py
@@ -1,5 +1,4 @@
 from {{ cookiecutter.package }}.files import VARIABLE_FILE
 from lume_model.utils import variables_from_yaml
 
-with open(VARIABLE_FILE, "r") as f:
-    INPUT_VARIABLES, OUTPUT_VARIABLES = variables_from_yaml(f)
+INPUT_VARIABLES, OUTPUT_VARIABLES = variables_from_yaml(VARIABLE_FILE)

--- a/template/{{ cookiecutter.repo_name }}/{{ cookiecutter.package }}/flow.py
+++ b/template/{{ cookiecutter.repo_name }}/{{ cookiecutter.package }}/flow.py
@@ -152,7 +152,7 @@ save_file_task = SaveFile(timeout=30)
 # load_db_result_task = LoadDBResult(timeout=10)
 
 
-def {{ cookiecutter.repo_name  }}_flow():
+def {{ cookiecutter.package }}_flow():
     logger = get_run_logger()
     logger.info(f'Starting flow run...')
     # CONFIGURE LUME-SERVICES

--- a/template/{{ cookiecutter.repo_name }}/{{ cookiecutter.package }}/flow.py
+++ b/template/{{ cookiecutter.repo_name }}/{{ cookiecutter.package }}/flow.py
@@ -1,7 +1,6 @@
 from typing import Dict
 
-from prefect import Flow, task, case
-from prefect import Parameter
+from prefect import flow, get_run_logger, task
 
 from lume_services.results import Result
 from lume_services.tasks import (
@@ -15,13 +14,12 @@ from lume_services.tasks import (
 )
 from lume_services.files import TextFile
 from lume_model.variables import InputVariable, OutputVariable
-from prefect.storage import Module
 
 from {{ cookiecutter.package }}.model import {{ cookiecutter.model_class }}
 from {{ cookiecutter.package }} import INPUT_VARIABLES
 
 
-@task(log_stdout=True)
+@task()
 def preprocessing_task(input_variables, misc_settings):
     """If additional preprocessing of input variables are required, process the
     variables here. This task is flexible and can absorb other misc settings passed
@@ -33,7 +31,6 @@ def preprocessing_task(input_variables, misc_settings):
 
         ```python
 
-        @task(log_stdout=True)
         def preprocessing_task(input_variables, multiplier):
             for var_name in input_variables.keys():
                 input_variables[var_name].value = input_variables[var_name].value
@@ -45,7 +42,7 @@ def preprocessing_task(input_variables, misc_settings):
     raise NotImplementedError("Called not implemented preprocessing_task in flow.")
 
 
-@task(log_stdout=True)
+@task()
 def format_file(output_variables):
     """Task used for organizing an file object. The formatted object must be
     serializable by the file_type passed in the SaveFile task call.
@@ -57,7 +54,7 @@ def format_file(output_variables):
         concatenate the text and save in a text file. This would look like:
         ```python
 
-        @task(log_stdout=True)
+        @task()
         def format_file(output_variables):
             text = output_variables["text1"].value + output_variables["text2"].value
             return text
@@ -87,7 +84,7 @@ def format_file(output_variables):
     raise NotImplementedError("Called not implemented format_file in flow.")
 
 
-@task(log_stdout=True)
+@task()
 def format_result(
     input_variables: Dict[str, InputVariable],
     output_variables: Dict[str, OutputVariable],
@@ -117,7 +114,17 @@ def format_result(
     return Result(inputs=inputs, outputs=outputs)
 
 
-@task(log_stdout=True)
+@task()
+def load_input(var_name, parameter):
+    # Confirm Inputs are Correctly Loaded!
+    logger = get_run_logger()
+    if parameter.value is None:
+        parameter.value = parameter.default
+    logger.info(f'Loaded {var_name} with value {parameter}')
+    return parameter
+
+
+@task()
 def evaluate(formatted_input_vars, settings=None):
 
     if settings is None:
@@ -145,27 +152,24 @@ save_file_task = SaveFile(timeout=30)
 # load_db_result_task = LoadDBResult(timeout=10)
 
 
-with Flow("{{ cookiecutter.repo_name }}", storage=Module(__name__)) as flow:
-
+def {{ cookiecutter.repo_name  }}_flow():
+    logger = get_run_logger()
+    logger.info(f'Starting flow run...')
     # CONFIGURE LUME-SERVICES
     # see https://slaclab.github.io/lume-services/workflows/#configuring-flows-for-use-with-lume-services
-    configure = configure_lume_services()
+    #configure = configure_lume_services()
 
     # CHECK WHETHER THE FLOW IS RUNNING LOCALLY
     # If the flow runs using a local backend, the results service will not be available
-    running_local = check_local_execution()
-    running_local.set_upstream(configure)
+    #running_local = check_local_execution()
+    #running_local.set_upstream(configure)
 
     # SET UP INPUT VARIABLE PARAMETERS.
     # These are parameters that can be supplied to the workflow at runtime
-    input_variable_parameter_dict = {
-        var_name: Parameter(var_name, default=var.default)
-        for var_name, var in INPUT_VARIABLES.items()
-    }
+    input_variable_parameter_dict = {}
+    for var in INPUT_VARIABLES:
+        input_variable_parameter_dict[var.name] = load_input(var.name, var)
 
-    # additional settings may be organized as parameters
-    # setting_1 = Parameter("setting_1")
-    # setting_2 = Parameter("setting_2")
 
     # If your model requires loading a file object, you can use the LoadFile task
     # pre-packaged with LUME-services. The load_file_task is defined in a comment above
@@ -208,7 +212,7 @@ with Flow("{{ cookiecutter.repo_name }}", storage=Module(__name__)) as flow:
     # This assumes the output is a text file, but see https://slaclab.github.io/lume-services/api/files/files/ # noqa
     # for custom types. If the formats supported do not suit your needs, you can
     # alternatively subclass File for custom serialization.
-    file_data = format_file(output_variables)
+    #file_data = format_file(output_variables)
 
 
     # MARK CONFIGURATION OF LUME_SERVICES AS AN UPSTREAM TASK
@@ -216,26 +220,26 @@ with Flow("{{ cookiecutter.repo_name }}", storage=Module(__name__)) as flow:
     # as an upstream task
 
     # add "filename" and "filesystem_identifier to the flow parameters"
-    file_parameters = save_file_task.parameters
-    saved_file_rep = save_file_task(file_data, file_type=TextFile, **file_parameters)
+    #file_parameters = save_file_task.parameters
+    #saved_file_rep = save_file_task(file_data, file_type=TextFile, **file_parameters)
 
 
     # MARK CONFIGURATION OF LUME_SERVICES AS AN UPSTREAM TASK
     # tasks using backend services like filesystem and results db must mark configure
     # as an upstream task
-    saved_file_rep.set_upstream(configure)
+    #saved_file_rep.set_upstream(configure)
 
 
-    # SAVE RESULTS TO RESULTS DATABASE, requires LUME-services results backend 
-    with case(running_local, False):
-        # CREATE LUME-services Result object
-        formatted_result = format_result(
-            input_variables=formatted_input_variables, output_variables=output_variables
-        )
+    # SAVE RESULTS TO RESULTS DATABASE, requires LUME-services results backend, still work in progress
+    #if not running_local:
+    #    # CREATE LUME-services Result object
+    #    formatted_result = format_result(
+    #        input_variables=formatted_input_variables, output_variables=output_variables
+    #    )
 
         # RUN DATABASE_SAVE_TASK
-        saved_model_rep = save_db_result_task(formatted_result)
-        saved_model_rep.set_upstream(configure)
+    #    saved_model_rep = save_db_result_task(formatted_result)
+    #    saved_model_rep.set_upstream(configure)
 
 
 def get_flow():


### PR DESCRIPTION
The majority of changes here are related to ensuring this template can run with prefect 2 and the newest lume-model. Some temporary changes pending continued development on lume-model as noted in various places.

Adds a `prefect.yaml` file that will work with a kubernetes based deployment for running prefect flows.

Further updates to model registration and results storage to follow based on potential MLFlow usage.