### PR TITLE
Impose Python<3.12 in `dev-environment`

### DIFF
--- a/template/{{ cookiecutter.repo_name }}/dev-environment.yml
+++ b/template/{{ cookiecutter.repo_name }}/dev-environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - click
   - pydantic # until lume-services registered with conda
   - graphviz
+  - python>=3.9,<3.12
   - python-graphviz
   - prefect
   - pip 


### PR DESCRIPTION
The `lume-services` [demo](https://slaclab.github.io/lume-services/demo/#6-create-development-environment) currently fails when using Python 3.12, because of this issue:
https://github.com/slaclab/lume-model/issues/92